### PR TITLE
Replay buffered console messages to new SSE clients

### DIFF
--- a/src/net/WebServer.cpp
+++ b/src/net/WebServer.cpp
@@ -48,10 +48,12 @@ void WebServer::initSse_() {
   events_.onConnect([this](AsyncEventSourceClient* client){
     Serial.println("WebServer: SSE-klient ansluten 📡");
     // Skicka initial data till den nya klienten
-    client->send(buildStatusJson_().c_str(), nullptr, millis()); 
+    client->send(buildStatusJson_().c_str(), nullptr, millis());
     client->send(buildActiveJson_(settings_.activeLinesMask).c_str(), "activeMask", millis());
     client->send(buildDebugJson_().c_str(), "debug", millis());
-    // Note: console-history (buffrade meddelanden) flushas av util::Console när sink registreras.
+    util::UIConsole::forEachBuffered([client](const String& json) {
+      client->send(json.c_str(), "console", millis());
+    });
   });
   server_.addHandler(&events_);
 }

--- a/src/util/UIConsole.h
+++ b/src/util/UIConsole.h
@@ -19,11 +19,13 @@ public:
   static void log(const String& text, const char* source = nullptr);
 
   // Registrera en sink (t.ex. WebServer) som hanterar JSON-strängar.
-  // När en sink registreras flushas buffern (om någon finns).
   static void setSink(ConsoleSink sink);
 
   // Ta bort sink (dvs. återgå till buffring)
   static void clearSink();
+
+  // Iterera över en kopia av bufferten på ett trådsäkert sätt
+  static void forEachBuffered(const std::function<void(const String&)>& fn);
 };
 
 } // namespace util


### PR DESCRIPTION
## Summary
- ensure the UI console ring buffer keeps history even when a sink is attached
- add a thread-safe iterator to read buffered console JSON messages
- replay buffered console history to newly connected SSE clients before streaming live events