### PR TITLE
Add configurable phone numbers per line

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -22,16 +22,61 @@ h1{ font-size:1.8rem; margin:0 0 16px }
   box-shadow:0 6px 30px rgba(0,0,0,.25);
 }
 
-/* tre kolumner: Namn | Status | Aktiv-knapp */
+/* fyra kolumner: Namn | Telefonnummer | Status | Aktiv-knapp */
 .row{
-  display:grid; grid-template-columns:1fr auto auto; gap:10px;
-  align-items:baseline; padding:8px 0;
+  display:grid; grid-template-columns:1fr minmax(200px, 2fr) auto auto; gap:10px;
+  align-items:center; padding:8px 0;
   border-bottom:1px dashed rgba(255,255,255,.06)
 }
 .row:last-child{ border-bottom:none }
 
 .k{ color:var(--muted) }
 .v{ font-weight:700; letter-spacing:.3px }
+
+.phone-cell{
+  display:flex;
+  gap:8px;
+  align-items:center;
+}
+
+.phone-input{
+  flex:1;
+  min-width:150px;
+  padding:4px 8px;
+  border-radius:6px;
+  border:1px solid var(--border);
+  background:rgba(255,255,255,0.04);
+  color:var(--fg);
+}
+
+.phone-input:focus{
+  outline:1px solid var(--accent);
+  outline-offset:1px;
+}
+
+.btn{
+  border:1px solid var(--border);
+  background:rgba(255,255,255,0.05);
+  color:var(--fg);
+  padding:4px 10px;
+  border-radius:999px;
+  font-size:.8rem;
+  cursor:pointer;
+}
+
+.btn.working{
+  opacity:.6;
+  pointer-events:none;
+}
+
+.phone-save{
+  border-color: var(--accent);
+  background: rgba(96, 165, 250, 0.15);
+}
+
+.phone-save:hover{
+  background: rgba(96, 165, 250, 0.25);
+}
 
 .status{ margin-top:10px; color:var(--muted); font-size:.9rem }
 

--- a/src/net/WebServer.h
+++ b/src/net/WebServer.h
@@ -51,6 +51,7 @@ private:
   String buildStatusJson_() const;
   String buildActiveJson_(uint8_t mask);
   String buildDebugJson_() const;
+  static String escapeJson_(const String& in);
 
   // Bind the util::Console sink to forward JSON messages to SSE "console"
   void bindConsoleSink_();

--- a/src/services/LineManager.h
+++ b/src/services/LineManager.h
@@ -12,6 +12,7 @@ public:
   void setStatus(int index, LineStatus newStatus);
   void clearChangeFlag(int index);
   void setLineTimer(int index, unsigned int limit);
+  void setPhoneNumber(int index, const String& number);
 
   using StatusChangedCallback = std::function<void(int /*lineIndex*/, model::LineStatus)>;
   using ActiveLinesChangedCallback = std::function<void(uint8_t)>;

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -1,4 +1,5 @@
 #include "settings.h"
+#include <cstdio>
 
 Settings::Settings() {
   resetDefaults();        // ensure fields have initial values
@@ -48,6 +49,10 @@ void Settings::resetDefaults() {
 
   // Runtime flags kept false here; set by MCPDriver::begin()
   mcpSlic1Present = mcpSlic2Present = mcpMainPresent = mcpMt8816Present = false;
+
+  for (int i = 0; i < 8; ++i) {
+    linePhoneNumbers[i] = String(i);
+  }
   Serial.println("Settings reset to defaults");
   util::UIConsole::log("Settings reset to defaults", "Settings");
 }
@@ -83,6 +88,16 @@ bool Settings::load() {
     digitGapMinMs         = prefs.getUInt ("digitGapMinMs",        digitGapMinMs);
     globalPulseTimeoutMs  = prefs.getUInt ("globalPulseTO",        globalPulseTimeoutMs);
     highMeansOffHook      = prefs.getBool ("hiOffHook",            highMeansOffHook);
+
+    for (int i = 0; i < 8; ++i) {
+      char key[16];
+      snprintf(key, sizeof(key), "linePhone%d", i);
+      char value[33];
+      size_t len = prefs.getString(key, value, sizeof(value));
+      if (len > 0) {
+        linePhoneNumbers[i] = String(value);
+      }
+    }
   }
   prefs.end();
   if (!ok) save();
@@ -115,6 +130,12 @@ void Settings::save() const {
   prefs.putUInt ("digitGapMinMs",        digitGapMinMs);
   prefs.putUInt ("globalPulseTO",        globalPulseTimeoutMs);
   prefs.putBool ("hiOffHook",            highMeansOffHook);
+
+  for (int i = 0; i < 8; ++i) {
+    char key[16];
+    snprintf(key, sizeof(key), "linePhone%d", i);
+    prefs.putString(key, linePhoneNumbers[i]);
+  }
 
   prefs.end();
 }

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -49,6 +49,9 @@ public:
 
   uint8_t allowMask;
 
+  // ---- Line metadata ----
+  String linePhoneNumbers[8];     // Configured phone number for each line
+
   // ---- MCP statuses (not saved to NVS, runtime only) ----
   bool mcpSlic1Present = false;
   bool mcpSlic2Present = false;

--- a/src/util/StatusSerializer.cpp
+++ b/src/util/StatusSerializer.cpp
@@ -2,8 +2,37 @@
 #include "services/LineManager.h"
 #include "services/LineHandler.h"
 #include "model/Types.h"
+#include <cstdio>
 
 namespace net {
+
+namespace {
+String escapeJsonString(const String& s) {
+  String out;
+  out.reserve(s.length());
+  for (size_t i = 0; i < s.length(); ++i) {
+    char c = s[i];
+    switch (c) {
+      case '\\': out += "\\\\"; break;
+      case '\"': out += "\\\""; break;
+      case '\b': out += "\\b";  break;
+      case '\f': out += "\\f";  break;
+      case '\n': out += "\\n";  break;
+      case '\r': out += "\\r";  break;
+      case '\t': out += "\\t";  break;
+      default:
+        if ((uint8_t)c < 0x20) {
+          char buf[8];
+          snprintf(buf, sizeof(buf), "\\u%04x", (uint8_t)c);
+          out += buf;
+        } else {
+          out += c;
+        }
+    }
+  }
+  return out;
+}
+} // namespace
 
 String buildLinesStatusJson(const LineManager& lm) {
   // Bygg manuellt för att slippa externa libbar. Lätt att utöka fält senare.
@@ -12,6 +41,7 @@ String buildLinesStatusJson(const LineManager& lm) {
     const auto& line = const_cast<LineManager&>(lm).getLine(i); // getLine saknar const-variant
     out += "{\"id\":" + String(i);
     out += ",\"status\":\""; out += model::toString(line.currentLineStatus); out += "\"";
+    out += ",\"phone\":\""; out += escapeJsonString(line.phoneNumber); out += "\"";
     // Lägg till fler fält här när du vill skala upp:
     // out += ",\"active\":"; out += (line.lineActive ? "true" : "false");
     // out += ",\"hook\":\"";  out += (line.SHK ? "Off" : "On"); out += "\"";


### PR DESCRIPTION
## Summary
- persist a phone number for each line in settings and expose it via the line manager/status JSON
- add a web API endpoint to update line phone numbers and broadcast the changes live
- extend the web UI with editable phone number inputs tied to the new endpoint

## Testing
- not run (embedded project)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69022a371c488320a85b132f7aedebfe)