### PR TITLE
Reset tone reader state when debug level changes

### DIFF
--- a/src/services/ToneReader.cpp
+++ b/src/services/ToneReader.cpp
@@ -4,6 +4,16 @@ ToneReader::ToneReader(MCPDriver& mcpDriver, Settings& settings, LineManager& li
   : mcpDriver_(mcpDriver), settings_(settings), lineManager_(lineManager) {}
 
 void ToneReader::update() {
+  // Reset state when debug level changes so lower levels don't inherit stale
+  // edge/debounce tracking from earlier verbose sessions.
+  static uint8_t lastDebugLevel = settings_.debugTRLevel;
+  if (settings_.debugTRLevel != lastDebugLevel) {
+    lastDebugLevel   = settings_.debugTRLevel;
+    lastStdLevel_    = false;
+    lastDtmfNibble_  = INVALID_DTMF_NIBBLE;
+    lastDtmfTime_    = 0;
+  }
+
   // Debug: Check STD pin state and print only on change
   static bool lastDebugStdLevel = false;
   static bool firstCheck = true;


### PR DESCRIPTION
## Summary
- reset ToneReader edge/debounce state when debugTRLevel changes to prevent stale tracking after switching levels

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69357f7215dc83209ae9aaf0ab12bc0f)