### PR TITLE
Use ring-aware hook stability duration

### DIFF
--- a/src/services/SHKService.h
+++ b/src/services/SHKService.h
@@ -52,7 +52,8 @@ private:
   uint32_t readShkMask_() const;
 
   // Logik
-  void updateHookFilter_(int idx, bool rawHigh, uint32_t nowMs);
+  void updateHookFilter_(int idx, bool rawHigh, uint32_t nowMs, uint32_t hookStableMs);
+  uint32_t getHookStableMs_(int idx) const;
   void setStableHook(int index, bool offHook, bool rawHigh, uint32_t nowMs);
   void updatePulseDetector_(int idx, bool rawHigh, uint32_t nowMs);
   bool pulseModeAllowed_(const LineHandler& line) const;


### PR DESCRIPTION
## Summary
- calculate hook stability duration based on ringing state to tolerate SHK noise while FR toggles
- reuse the same ring-aware duration when filtering hooks and managing burst activity
- keep hook stability timing in a wider type to avoid truncation during ringing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dd4f2302c8320998ff6cac3d09327)