### PR TITLE
Fix LineManager and ToneReader initialization dependencies

### DIFF
--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -5,20 +5,22 @@ App::App()
   : mcpDriver_(),
     interruptManager_(mcpDriver_, Settings::instance()),
     mt8816Driver_(mcpDriver_, Settings::instance()),
-    lineManager_(Settings::instance(), &toneReader_),
-    ringGenerator_(mcpDriver_, Settings::instance(), lineManager_),
 
     toneGenerator1_(cfg::ad9833::CS1_PIN),
-    toneGenerator2_(cfg::ad9833::CS2_PIN),  
+    toneGenerator2_(cfg::ad9833::CS2_PIN),
     toneGenerator3_(cfg::ad9833::CS3_PIN),
-    toneReader_(interruptManager_, mcpDriver_, Settings::instance(), lineManager_),
 
+    lineManager_(Settings::instance()),
+    toneReader_(interruptManager_, mcpDriver_, Settings::instance(), lineManager_),
+    ringGenerator_(mcpDriver_, Settings::instance(), lineManager_),
     SHKService_(lineManager_, interruptManager_, mcpDriver_, Settings::instance(), ringGenerator_),
     lineAction_(lineManager_, Settings::instance(), mt8816Driver_, ringGenerator_, toneReader_,
                 toneGenerator1_, toneGenerator2_, toneGenerator3_),
-    
+
     webServer_(Settings::instance(), lineManager_, wifiClient_, ringGenerator_, lineAction_, 80),
-    functionButton_(interruptManager_) {}
+    functionButton_(interruptManager_) {
+    lineManager_.setToneReader(&toneReader_);
+}
 
 void App::begin() {
     Serial.begin(115200);

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -33,19 +33,20 @@ public:
     void loop();
 
     MCPDriver mcpDriver_;
+    InterruptManager interruptManager_;
     MT8816Driver mt8816Driver_;
 
 private:
-    
-    LineManager lineManager_;
-    SHKService SHKService_;
-    LineAction lineAction_;
+
     ToneGenerator toneGenerator1_;
     ToneGenerator toneGenerator2_;
     ToneGenerator toneGenerator3_;
+
+    LineManager lineManager_;
     ToneReader toneReader_;
     RingGenerator ringGenerator_;
-    InterruptManager interruptManager_;
+    SHKService SHKService_;
+    LineAction lineAction_;
 
     net::WifiClient wifiClient_;
     net::Provisioning provisioning_;

--- a/src/services/LineManager.h
+++ b/src/services/LineManager.h
@@ -2,15 +2,16 @@
 #include <functional>
 #include "settings/settings.h"
 #include "model/Types.h"
-#include "services/ToneReader.h"
 #include "util/UIConsole.h"
 #include "LineHandler.h"
+
+class ToneReader;
 
 class LineManager {
 public:
   LineManager(Settings& settings);
   void begin();
-  void setToneReader(ToneReader* toneReader){ toneReader_ = toneReader; };
+  void setToneReader(ToneReader* toneReader) { toneReader_ = toneReader; };
   void syncLineActive(size_t i);
   void setStatus(int index, LineStatus newStatus);
   void clearChangeFlag(int index);

--- a/src/services/ToneReader.cpp
+++ b/src/services/ToneReader.cpp
@@ -1,4 +1,5 @@
 #include "services/ToneReader.h"
+#include "services/LineManager.h"
 
 ToneReader::ToneReader(InterruptManager& interruptManager, MCPDriver& mcpDriver, Settings& settings, LineManager& lineManager)
   : interruptManager_(interruptManager), mcpDriver_(mcpDriver), settings_(settings), lineManager_(lineManager) {}

--- a/src/services/ToneReader.h
+++ b/src/services/ToneReader.h
@@ -3,8 +3,9 @@
 #include "config.h"
 #include "drivers/InterruptManager.h"
 #include "drivers/MCPDriver.h"
-#include "services/LineManager.h"
 #include "settings.h"
+
+class LineManager;
 
 class ToneReader {
   public:


### PR DESCRIPTION
## Summary
- break the circular include between LineManager and ToneReader using forward declarations
- reorder App member declarations/initialization and set ToneReader on LineManager after construction
- ensure ToneReader has the required LineManager definition in its implementation file

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ed26f7f5c8320ba8e9ffa7fc5693f)