### PR TITLE
Add GPIOTest helper for MCP pin change debugging

### DIFF
--- a/src/app/App.h
+++ b/src/app/App.h
@@ -37,6 +37,7 @@ public:
     MT8816Driver mt8816Driver_;
 
 private:
+    void GPIOTest(uint8_t addr, int pin);
 
     ToneGenerator toneGenerator1_;
     ToneGenerator toneGenerator2_;


### PR DESCRIPTION
### Motivation
- Göra det enkelt att debugga och övervaka enskilda GPIO-pinnar på MCP-enheterna genom att logga endast vid förändring, för att undvika serieljud.
- Möjliggöra snabb felsökning från `App::loop()` utan att ändra befintlig logik i andra moduler.

### Description
- Lagt till privat funktion deklaration `void GPIOTest(uint8_t addr, int pin);` i `src/app/App.h`.
- Implementerat `App::GPIOTest` i `src/app/App.cpp` som använder `mcpDriver_.digitalReadMCP(...)`, lagrar första mätningen tyst och skriver till Serial endast när pin-värdet ändras; funktionen stödjer upp till 8 parallella bevakningar med en intern tabell.
- Anrop till `GPIOTest(cfg::mcp::MCP_MAIN_ADDRESS, cfg::mcp::FUNCTION_BUTTON)` kopplades in i `App::loop()` bakom debug-triggern `settings.debugMCPLevel >= 1` så beteendet är inaktiverat i normal drift.

### Testing
- Ett försök att bygga kördes med `platformio run`, men det misslyckades i den här miljön eftersom `platformio` inte finns (`command not found`).
- Inga automatiska enhetstester kördes i denna miljö efter ändringen.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69872b0c62c08320a670a38bb22f52df)